### PR TITLE
Fix resolution raster offset due to data definition at cells for geot…

### DIFF
--- a/gmsh/exportGeometry.py
+++ b/gmsh/exportGeometry.py
@@ -153,8 +153,10 @@ def writeRasterLayer(layer, filename) :
     progress.setValue(0)
     f = open(filename, "wb")
     ext = layer.extent()
-    f.write(struct.pack("3d", ext.xMinimum(), ext.yMinimum(), 0))
-    f.write(struct.pack("3d", ext.width() / layer.width(), ext.height() / layer.height(), 1))
+    dx = ext.width() / layer.width()
+    dy = ext.height() / layer.height()
+    f.write(struct.pack("3d", ext.xMinimum() + 0.5 * dx, ext.yMinimum() + 0.5 * dy, 0))
+    f.write(struct.pack("3d", dx, dy, 1))
     f.write(struct.pack("3i", layer.width(), layer.height(), 1))
     block = layer.dataProvider().block(1, layer.extent(), layer.width(), layer.height())
     for j in range(layer.width()) : 


### PR DESCRIPTION
Hi Jon,

I noticed that the mesh resolution was off compared to the geotiff resolution raster. Is suspect the cause to be the cell-based data for geotiff vs grid-based data for gmsh struct arrays (1/2 cell offset). 

This commit should fix it (works in my case).

Cheers!
Seb 